### PR TITLE
Removed dynamic from library option in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ import PackageDescription
 let package = Package(
     name: "BTree",
     products: [
-        .library(name: "BTree", type: .dynamic, targets: ["BTree"])
+        .library(name: "BTree", targets: ["BTree"])
     ],
     dependencies: [
     ],


### PR DESCRIPTION
Removed dynamic from library option in Package.swift to let client project determine whether to link dynamically or staticly against BTree.

This is the recommended approach as can be read here: https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4.md

I suffer from this in my own project where I want to link staticly against BTree.

Mind also that it is not possible to override it once specified: https://forums.swift.org/t/building-distributable-executable-using-swiftpm/13792