### PR TITLE
BTree supports Codable

### DIFF
--- a/Sources/BTree.swift
+++ b/Sources/BTree.swift
@@ -1071,3 +1071,7 @@ extension BTree {
         return suffix(from: start).prefix(through: stop)
     }
 }
+
+#if swift(>=4.2)
+extension BTree:Codable where Key: Codable, Value:Codable {}
+#endif

--- a/Sources/BTreeIndex.swift
+++ b/Sources/BTreeIndex.swift
@@ -192,3 +192,9 @@ internal struct BTreeWeakPath<Key: Comparable, Value>: BTreePath {
         }
     }
 }
+
+#if swift(>=4.2)
+extension BTreeWeakPath: Codable where Key: Codable, Value: Codable {}
+
+extension BTreeIndex: Codable where Key: Codable, Value: Codable {}
+#endif

--- a/Sources/BTreeIterator.swift
+++ b/Sources/BTreeIterator.swift
@@ -54,7 +54,7 @@ public struct BTreeValueIterator<Value>: IteratorProtocol {
 
 /// An iterator for the keys stored in a B-tree without a value.
 public struct BTreeKeyIterator<Key: Comparable>: IteratorProtocol {
-    internal typealias Base = BTreeIterator<Key, Void>
+    internal typealias Base = BTreeIterator<Key, EmptyValue>
     fileprivate var base: Base
 
     internal init(_ base: Base) {
@@ -147,3 +147,15 @@ internal struct BTreeStrongPath<Key: Comparable, Value>: BTreePath {
         }
     }
 }
+
+#if swift(>=4.2)
+extension EmptyKey: Codable {}
+
+extension BTreeKeyIterator: Codable where Key: Codable {}
+
+extension BTreeValueIterator: Codable where Value: Codable {}
+
+extension BTreeIterator: Codable where Key: Codable, Value: Codable {}
+
+extension BTreeStrongPath: Codable where Key: Codable, Value: Codable {}
+#endif

--- a/Sources/List.swift
+++ b/Sources/List.swift
@@ -565,3 +565,7 @@ extension List {
         return result
     }
 }
+
+#if swift(>=4.2)
+extension List: Codable where Element: Codable {}
+#endif

--- a/Sources/Map.swift
+++ b/Sources/Map.swift
@@ -564,3 +564,7 @@ extension Map {
         return excluding(SortedSet(keys))
     }
 }
+
+#if swift(>=4.2)
+extension Map: Codable where Key: Codable, Value: Codable {}
+#endif

--- a/Sources/SortedBag.swift
+++ b/Sources/SortedBag.swift
@@ -24,7 +24,7 @@
 ///
 /// - SeeAlso: `SortedSet`
 public struct SortedBag<Element: Comparable>: SetAlgebra {
-    internal typealias Tree = BTree<Element, Void>
+    internal typealias Tree = BTree<Element, EmptyValue>
 
     /// The b-tree that serves as storage.
     internal fileprivate(set) var tree: Tree
@@ -54,7 +54,7 @@ extension SortedBag {
     ///
     /// - Complexity: O(*n* * log(*n*)), where *n* is the number of items in the sequence.
     public init<S: Sequence>(_ elements: S) where S.Element == Element {
-        self.init(Tree(sortedElements: elements.sorted().lazy.map { ($0, ()) }, dropDuplicates: false))
+        self.init(Tree(sortedElements: elements.sorted().lazy.map { ($0, EmptyValue.def) }, dropDuplicates: false))
     }
 
     /// Create a bag from a sorted finite sequence of items.
@@ -62,7 +62,7 @@ extension SortedBag {
     ///
     /// - Complexity: O(*n*), where *n* is the number of items in the sequence.
     public init<S: Sequence>(sortedElements elements: S) where S.Element == Element {
-        self.init(Tree(sortedElements: elements.lazy.map { ($0, ()) }, dropDuplicates: false))
+        self.init(Tree(sortedElements: elements.lazy.map { ($0, EmptyValue.def) }, dropDuplicates: false))
     }
 
     /// Create a bag with the specified list of items.
@@ -75,7 +75,7 @@ extension SortedBag {
 extension SortedBag: BidirectionalCollection {
     //MARK: CollectionType
 
-    public typealias Index = BTreeIndex<Element, Void>
+    public typealias Index = BTreeIndex<Element, EmptyValue>
     public typealias Iterator = BTreeKeyIterator<Element>
     public typealias SubSequence = SortedBag<Element>
 
@@ -442,7 +442,7 @@ extension SortedBag {
     /// Returns the index of the first instance of a given member, or `nil` if the member is not present in the bag.
     ///
     /// - Complexity: O(log(`count`))
-    public func index(of member: Element) -> BTreeIndex<Element, Void>? {
+    public func index(of member: Element) -> BTreeIndex<Element, EmptyValue>? {
         return tree.index(forKey: member, choosing: .first)
     }
 
@@ -451,7 +451,7 @@ extension SortedBag {
     /// This function never returns `endIndex`. (If it returns non-nil, the returned index can be used to subscript the bag.)
     ///
     /// - Complexity: O(log(`count`))
-    public func indexOfFirstElement(after element: Element) -> BTreeIndex<Element, Void>? {
+    public func indexOfFirstElement(after element: Element) -> BTreeIndex<Element, EmptyValue>? {
         let index = tree.index(forInserting: element, at: .last)
         if tree.offset(of: index) == tree.count { return nil }
         return index
@@ -462,7 +462,7 @@ extension SortedBag {
     /// This function never returns `endIndex`. (If it returns non-nil, the returned index can be used to subscript the bag.)
     ///
     /// - Complexity: O(log(`count`))
-    public func indexOfFirstElement(notBefore element: Element) -> BTreeIndex<Element, Void>? {
+    public func indexOfFirstElement(notBefore element: Element) -> BTreeIndex<Element, EmptyValue>? {
         let index = tree.index(forInserting: element, at: .first)
         if tree.offset(of: index) == tree.count { return nil }
         return index
@@ -473,7 +473,7 @@ extension SortedBag {
     /// This function never returns `endIndex`. (If it returns non-nil, the returned index can be used to subscript the bag.)
     ///
     /// - Complexity: O(log(`count`))
-    public func indexOfLastElement(before element: Element) -> BTreeIndex<Element, Void>? {
+    public func indexOfLastElement(before element: Element) -> BTreeIndex<Element, EmptyValue>? {
         var index = tree.index(forInserting: element, at: .first)
         if tree.offset(of: index) == 0 { return nil }
         tree.formIndex(before: &index)
@@ -485,7 +485,7 @@ extension SortedBag {
     /// This function never returns `endIndex`. (If it returns non-nil, the returned index can be used to subscript the bag.)
     ///
     /// - Complexity: O(log(`count`))
-    public func indexOfLastElement(notAfter element: Element) -> BTreeIndex<Element, Void>? {
+    public func indexOfLastElement(notAfter element: Element) -> BTreeIndex<Element, EmptyValue>? {
         var index = tree.index(forInserting: element, at: .last)
         if tree.offset(of: index) == 0 { return nil }
         tree.formIndex(before: &index)
@@ -600,7 +600,7 @@ extension SortedBag {
     /// - Complexity: O(log(`count`))
     @discardableResult
     public mutating func insert(_ newMember: Element) -> (inserted: Bool, memberAfterInsert: Element) {
-        tree.insert((newMember, ()), at: .after)
+        tree.insert((newMember, EmptyValue.def), at: .after)
         return (true, newMember)
     }
 
@@ -617,7 +617,7 @@ extension SortedBag {
     /// - Returns: Always returns `nil`, to satisfy the syntactic requirements of the `SetAlgebra` protocol.
     @discardableResult
     public mutating func update(with newMember: Element) -> Element? {
-        tree.insert((newMember, ()), at: .first)
+        tree.insert((newMember, EmptyValue.def), at: .first)
         return nil
     }
 }
@@ -984,3 +984,7 @@ extension SortedBag where Element: Strideable {
     }
 
 }
+
+#if swift(>=4.2)
+extension SortedBag: Codable where Element: Codable {}
+#endif

--- a/Sources/Weak.swift
+++ b/Sources/Weak.swift
@@ -13,3 +13,7 @@ internal struct Weak<T: AnyObject> {
         self.value = value
     }
 }
+
+#if swift(>=4.2)
+extension Weak: Codable where T: Codable {}
+#endif

--- a/Tests/BTreeTests/BTreeNodeTests.swift
+++ b/Tests/BTreeTests/BTreeNodeTests.swift
@@ -492,4 +492,22 @@ class BTreeNodeTests: XCTestCase {
         node.assertValid()
         assertEqualElements(node, (0..<100).map { (0, $0) })
     }
+
+    #if swift(>=4.2)
+    func testCanBeCodedDecoded() {
+        let node = maximalNode(depth: 1, order: 5)
+        let encoder = PropertyListEncoder()
+        guard let data = try? encoder.encode(node) else {
+            XCTFail("failed encode")
+            return
+        }
+        let decoder = PropertyListDecoder()
+        guard let decodedNode = try? decoder.decode(Node.self, from: data) else {
+            XCTFail("failed decode")
+            return
+        }
+        assertEqualElements(IteratorSequence(decodedNode.makeIterator()),
+                            IteratorSequence(node.makeIterator()))
+    }
+    #endif
 }

--- a/Tests/BTreeTests/BTreeTests.swift
+++ b/Tests/BTreeTests/BTreeTests.swift
@@ -1236,4 +1236,22 @@ class BTreeTests: XCTestCase {
         tree.assertValid()
         assertEqualElements(tree, [(0, "0*"), (1, "1*"), (2, "2*"), (3, "3*"), (4, "4*")])
     }
+
+    #if swift(>=4.2)
+    func testCanBeCodedDecoded() {
+        let tree = Tree(minimalTree(depth: 2, order: 5))
+        let encoder = PropertyListEncoder()
+        guard let data = try? encoder.encode(tree) else {
+            XCTFail("failed encode")
+            return
+        }
+        let decoder = PropertyListDecoder()
+        guard let decodedTree = try? decoder.decode(Tree.self, from: data) else {
+            XCTFail("failed decode")
+            return
+        }
+        assertEqualElements(IteratorSequence(decodedTree.makeIterator()),
+                            IteratorSequence(tree.makeIterator()))
+    }
+    #endif
 }

--- a/Tests/BTreeTests/ListTests.swift
+++ b/Tests/BTreeTests/ListTests.swift
@@ -476,4 +476,22 @@ class ListTests: XCTestCase {
 
         assertEqualElements(l1 + l2, 0 ..< 20)
     }
+
+    #if swift(>=4.2)
+    func testCanBeCodedDecoded() {
+        let list: List<Int> = [0, 1, 2, 3, 4]
+        let encoder = PropertyListEncoder()
+        guard let data = try? encoder.encode(list) else {
+            XCTFail("failed encode")
+            return
+        }
+        let decoder = PropertyListDecoder()
+        guard let decodedList = try? decoder.decode(List<Int>.self, from: data) else {
+            XCTFail("failed decode")
+            return
+        }
+        assertEqualElements(IteratorSequence(decodedList.makeIterator()),
+                            IteratorSequence(list.makeIterator()))
+    }
+    #endif
 }

--- a/Tests/BTreeTests/MapTests.swift
+++ b/Tests/BTreeTests/MapTests.swift
@@ -440,4 +440,22 @@ class MapTests: XCTestCase {
         assertEqualElements(m.excluding([0, 5, 10, 15]), ([1 ..< 5, 6 ..< 10, 11 ..< 15, 16 ..< 20] as [CountableRange<Int>]).joined().map { (k) -> (Int, String) in (k, String(k)) })
         assertEqualElements(m.excluding(-10 ..< 30), [])
     }
+
+    #if swift(>=4.2)
+    func testCanBeCodedDecoded() {
+        let map = Map<Int, String>(sortedElements: (0..<100).map { ($0, String($0)) })
+        let encoder = PropertyListEncoder()
+        guard let data = try? encoder.encode(map) else {
+            XCTFail("failed encode")
+            return
+        }
+        let decoder = PropertyListDecoder()
+        guard let decodedMap = try? decoder.decode(Map<Int, String>.self, from: data) else {
+            XCTFail("failed decode")
+            return
+        }
+        assertEqualElements(IteratorSequence(decodedMap.makeIterator()),
+                            IteratorSequence(map.makeIterator()))
+    }
+    #endif
 }

--- a/Tests/BTreeTests/SortedBagTests.swift
+++ b/Tests/BTreeTests/SortedBagTests.swift
@@ -982,4 +982,23 @@ class SortedBagTests: XCTestCase {
 
         assertEqualElements(copy, [0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12, 14, 14, 16, 16, 18, 18])
     }
+
+    #if swift(>=4.2)
+    func testCanBeCodedDecoded() {
+        let c = 100
+        let bag = SortedBag((0 ..< c).map { 2 * $0 }.repeatEach(3))
+        let encoder = PropertyListEncoder()
+        guard let data = try? encoder.encode(bag) else {
+            XCTFail("failed encode")
+            return
+        }
+        let decoder = PropertyListDecoder()
+        guard let decodedBag = try? decoder.decode(SortedBag<Int>.self, from: data) else {
+            XCTFail("failed decode")
+            return
+        }
+        assertEqualElements(IteratorSequence(decodedBag.makeIterator()),
+                            IteratorSequence(bag.makeIterator()))
+    }
+    #endif
 }

--- a/Tests/BTreeTests/SortedSetTests.swift
+++ b/Tests/BTreeTests/SortedSetTests.swift
@@ -694,4 +694,23 @@ class SortedSetTests: XCTestCase {
         a.shift(startingAt: 15, by: -5)
         assertEqualElements(a, [0, 3, 5, 7, 8])
     }
+
+    #if swift(>=4.2)
+    func testCanBeCodedDecoded() {
+        let c = 1_000
+        let set = SortedSet((0 ..< c).reversed())
+        let encoder = PropertyListEncoder()
+        guard let data = try? encoder.encode(set) else {
+            XCTFail("failed encode")
+            return
+        }
+        let decoder = PropertyListDecoder()
+        guard let decodedSet = try? decoder.decode(SortedSet<Int>.self, from: data) else {
+            XCTFail("failed decode")
+            return
+        }
+        assertEqualElements(IteratorSequence(decodedSet.makeIterator()),
+                            IteratorSequence(set.makeIterator()))
+    }
+    #endif
 }


### PR DESCRIPTION
Hey, 

thank you for the BTree, I use it in my other pet project and it works flawlessly!

This is an attempt to support of Swift Codable to BTree.

The pull request might be much smaller if Swift Tuple type and Void type supported Codable out of the box. With the current Swift state, tuple support can be fixed "internally", without many changes.

But SortedSet and SortedBag being BTree<Element, Void> is a bummer, as in extension that means, that BTree<Codable, Codable> should be Codable, and BTree<Codable, Void> should be Codable and it appears that is not allowed. Hence the need for EmptyValue.

I understand it is a big code change just to support Codable, so feel free to reject.
I would be very excited if we agree on a different workaround for this, looking forward to your comments!

Also,
this works with Swift 4.2, what would be the best way to change the Swift version in podspec?
Having multiple pods for different versions? To be honest, I am not very familiar with versioning pods for different Swift versions.



